### PR TITLE
fix ReferenceError on 'gl'

### DIFF
--- a/src/Graphics/WebGL.js
+++ b/src/Graphics/WebGL.js
@@ -52,7 +52,7 @@
                 return function() {
                   var canvas = document.getElementById(canvasId);
                   try {
-                    gl = canvas.getContext("webgl", attr) || canvas.getContext("experimental-webgl", attr);
+                    window.gl = canvas.getContext("webgl", attr) || canvas.getContext("experimental-webgl", attr);
                   }
                   catch(e) {return false;}
                   if (!gl)


### PR DESCRIPTION
Didn't anyone else get this error? The function returns false even when there is an available context as it catches a ReferenceError [here](https://github.com/jutaro/purescript-webgl/blob/master/src/Graphics/WebGL.js#L57) because 'gl' is not defined. It was probably meant to be a global variable but it's using strict mode so I don't know if this was intented or not.

Note: I'm using Chrome.
